### PR TITLE
Add `protocol` option to prevent "Mixed content" error in Firefox

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -53,11 +52,12 @@ function validateConfig() {
 function Upload(file, opts) {
   if (!(this instanceof Upload)) return new Upload(file, opts);
   opts = opts || {};
+  if (!opts.protocol) opts.protocol = window.location.protocol;
   validateConfig();
   this.file = file;
   this.type = opts.type || file.type || 'application/octet-stream';
   this.name = opts.name || file.name;
-  this.bucketUrl = 'http://' + S3.bucket + '.s3.amazonaws.com';
+  this.bucketUrl = opts.protocol + '//' + S3.bucket + '.s3.amazonaws.com';
   this.url = this.bucketUrl + '/' + this.name;
   this.signature = S3.signature;
   this.bucket = S3.bucket;


### PR DESCRIPTION
If you are on an `https` domain and you try to upload to an s3 bucket under `http`, it will throw an error (at least in Firefox):

https://blog.mozilla.org/tanvi/2013/04/10/mixed-content-blocking-enabled-in-firefox-23/

The error looked like this:

[![https://blog.mozilla.org/security/files/2013/06/WebConsoleMixedContentOutput.jpg](https://blog.mozilla.org/security/files/2013/06/WebConsoleMixedContentOutput.jpg)](https://blog.mozilla.org/security/files/2013/06/WebConsoleMixedContentOutput.jpg)
